### PR TITLE
[FIX]: Should not remove all notifications. This could possibly remove user's observer handlers.

### DIFF
--- a/MaryPopin/UIViewController+MaryPopin.m
+++ b/MaryPopin/UIViewController+MaryPopin.m
@@ -237,7 +237,9 @@ CG_INLINE CGRect    BkRectInRectWithAlignementOption(CGRect myRect, CGRect refRe
 - (void)dismissCurrentPopinControllerAnimated:(BOOL)animated completion:(void(^)(void))completion
 {
     UIViewController *presentedPopin = self.presentedPopinViewController;
-    [[NSNotificationCenter defaultCenter] removeObserver:presentedPopin];
+
+    [[NSNotificationCenter defaultCenter] removeObserver:presentedPopin name:UIKeyboardWillHideNotification object:nil];
+    [[NSNotificationCenter defaultCenter] removeObserver:presentedPopin name:UIKeyboardWillShowNotification object:nil];
     
     if (YES == animated) {
         //Remove child with animation


### PR DESCRIPTION
Hi,

The category should not blindly remove all notification observers. Instead, it should only remove the notifications it's responsible for.

Thanks.
