### PR TITLE
FIX bad remove of poplin hierarchy

### DIFF
--- a/MaryPopin/UIViewController+MaryPopin.m
+++ b/MaryPopin/UIViewController+MaryPopin.m
@@ -395,9 +395,8 @@ CG_INLINE CGRect    BkRectInRectWithAlignementOption(CGRect myRect, CGRect refRe
     if (NO == [self.presentedPopinViewController popinTransitionUsesDynamics] || self.animator == nil) {
         [presentedPopin willMoveToParentViewController:nil];
         [presentedPopin.view removeFromSuperview];
-        
         [presentedPopin removeFromParentViewController];
-        [self setPresentedPopinViewController:nil];
+        [presentedPopin setPresentingPopinViewController:nil];
         [self setPresentingPopinViewController:nil];
     }
 }


### PR DESCRIPTION
1. this bug appears when presenting a second popin on the current presentedPopin
2. Why this remove of poplin hierarchy drives with that condition ?

``` objc
 if (NO == [self.presentedPopinViewController popinTransitionUsesDynamics] || self.animator == nil) 
```
