### PR TITLE
Feature/navigation bar layout

### DIFF
--- a/MaryPopin/UIViewController+MaryPopin.m
+++ b/MaryPopin/UIViewController+MaryPopin.m
@@ -169,6 +169,8 @@ CG_INLINE CGRect    BkRectInRectWithAlignementOption(CGRect myRect, CGRect refRe
             [self addPopinToHierarchy:popinController];
             CGRect popinFrame = [self computePopinFrame:popinController inRect:rect];
             [popinController.view setFrame:popinFrame];
+            [popinController didMoveToParentViewController:self];
+            [self forwardAppearanceEndingIfNeeded:popinController];
             
             if ([popinController popinTransitionUsesDynamics] ) {
                 [self snapInAnimationForPopinController:popinController toPosition:popinFrame withDirection:popinController.popinTransitionDirection completion:completion];
@@ -181,8 +183,6 @@ CG_INLINE CGRect    BkRectInRectWithAlignementOption(CGRect myRect, CGRect refRe
                                     options:UIViewAnimationOptionCurveEaseInOut
                                  animations:[self inAnimationForPopinController:popinController toPosition:popinFrame]
                                  completion:^(BOOL finished) {
-                                     [popinController didMoveToParentViewController:self];
-                                     [self forwardAppearanceEndingIfNeeded:popinController];
                                      if (completion) {
                                          completion();
                                      }
@@ -193,8 +193,6 @@ CG_INLINE CGRect    BkRectInRectWithAlignementOption(CGRect myRect, CGRect refRe
                     [UIView animateWithDuration:[UIViewController animationDurationForTransitionStyle:popinController.popinTransitionStyle]
                                      animations:[self inAnimationForPopinController:popinController toPosition:popinFrame]
                                      completion:^(BOOL finished) {
-                        [popinController didMoveToParentViewController:self];
-                        [self forwardAppearanceEndingIfNeeded:popinController];
                         if (completion) {
                             completion();
                         }

--- a/MaryPopinDemo/MaryPopinDemo/MaryPopinDemo-Info.plist
+++ b/MaryPopinDemo/MaryPopinDemo/MaryPopinDemo-Info.plist
@@ -24,6 +24,8 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile</key>
 	<string>Main_iPhone</string>
 	<key>UIMainStoryboardFile~ipad</key>

--- a/MaryPopinDemo/MaryPopinDemo/en.lproj/Main_iPhone.storyboard
+++ b/MaryPopinDemo/MaryPopinDemo/en.lproj/Main_iPhone.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="oFh-gd-Fba">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="oFh-gd-Fba">
     <dependencies>
         <deployment defaultVersion="1280" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
     </dependencies>
     <scenes>
-        <!--View Controller - MaryPopin Demo-->
+        <!--MaryPopin Demo-->
         <scene sceneID="SPa-bY-xbg">
             <objects>
                 <tableViewController title="MaryPopin Demo" id="0rz-QM-WR2" customClass="BKTViewController" sceneMemberID="viewController">
@@ -176,7 +176,7 @@
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="hn0-lO-HcK">
                                                     <rect key="frame" x="251" y="6" width="51" height="31"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
                                                     <inset key="insetFor6xAndEarlier" minX="30" minY="0.0" maxX="-30" maxY="0.0"/>
                                                     <connections>
                                                         <action selector="isDismissableValueChanged:" destination="L8y-BV-3Wo" eventType="valueChanged" id="w4M-PI-xcb"/>
@@ -204,7 +204,7 @@
                                             <subviews>
                                                 <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" id="eIz-OZ-iav">
                                                     <rect key="frame" x="20" y="38" width="280" height="29"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                     <segments>
                                                         <segment title="Center"/>
                                                         <segment title="Up"/>


### PR DESCRIPTION
A little workaround about an issue (not already open).
How reproduce this issue ? 
1) create a full screen controller with a navigation controller with a "status bar", the height appearance of the navigationBar is 64px
2) present a navigationController popin controller on the navigation controller of your full screen controller.
3) a second layout is done after the animation (to change navigation bar height)

The workaround is to call "endAppearanceTransition" before the finish completionBlock.
Any better genius idea?
