### PR TITLE
Typo-Fix that propagates to other pods

### DIFF
--- a/MaryPopin/UIViewController+MaryPopin.h
+++ b/MaryPopin/UIViewController+MaryPopin.h
@@ -356,7 +356,7 @@ typedef NS_ENUM(NSInteger, BKTPopinAlignementOption) {
 /**
  *  The options to apply to the popin. For a list of possible options, see BKTPopinAlignementOption
  *
- *  @param popinAlignement The BKTPopinAlignementOption values separated by | character.
+ *  @param popinAlignment The BKTPopinAlignementOption values separated by | character.
  *  @since v1.3
  */
 - (void)setPopinAlignment:(BKTPopinAlignementOption)popinAlignment;


### PR DESCRIPTION
MaryPopin still works nice and smoothly, but unfortunately the latest Xcode version will show a warning when a project uses this (at least when it's added as a pod). That even propagates to other pods having a dependency to MaryPopin. It's just a warning, but I'd still propose to fix this, as it is a tiny bit "ugly" to have that triangle in a project. :)